### PR TITLE
Added copy constructor for ToolMessageData.

### DIFF
--- a/plugin_tooling/src-lang/melnorme/lang/tooling/toolchain/ops/BuildOutputParser2.java
+++ b/plugin_tooling/src-lang/melnorme/lang/tooling/toolchain/ops/BuildOutputParser2.java
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     Bruno Medeiros - initial API and implementation
+ *     Pieter Penninckx - added copy constructor for ToolMessageData
  *******************************************************************************/
 package melnorme.lang.tooling.toolchain.ops;
 
@@ -121,6 +122,24 @@ public abstract class BuildOutputParser2 extends AbstractToolResultParser<ArrayL
 		
 		public String sourceBeforeMessageText;
 		public String messageText;
+		
+		// Copy constructor
+		public ToolMessageData(ToolMessageData init) {
+			this.pathString = init.pathString;
+			this.lineString = init.lineString;
+			this.columnString = init.columnString;
+			this.endLineString = init.endLineString;
+			this.endColumnString = init.endColumnString;
+			
+			this.messageTypeString = init.messageTypeString;
+			
+			this.sourceBeforeMessageText = init.sourceBeforeMessageText;
+			this.messageText = init.messageText;
+		}
+		
+		// Default constructor
+		public ToolMessageData() {
+		}
 		
 	}
 	


### PR DESCRIPTION
Added a simple copy constructor to the `ToolMessageData` class (nested class in `melnorme.lang.tooling.toolchain.ops.BuildOutputParser2`).
## Motivation

I'm working on RustDt/RustDt#130 . In RustDt, `CompositeToolMessageData` is a subclass of `ToolMessageData`. I want to extend `CompositeToolMessageData` with a constructor that takes a `ToolMessageData` object. The cleanest way (in my eyes) to implement such a constructor is to call the copy constructor of the super class (namely `ToolMessageData`). Hence the pull request.
